### PR TITLE
Add pages rendering API results

### DIFF
--- a/pages/entries.js
+++ b/pages/entries.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Entries() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/entries')
+      .then((res) => {
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Entries</h1>
+      <Link href="/"><button>Back</button></Link>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {!data && !error && <p>Loading...</p>}
+      {data && <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/pages/invoices.js
+++ b/pages/invoices.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Invoices() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/invoices')
+      .then((res) => {
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Invoices</h1>
+      <Link href="/"><button>Back</button></Link>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {!data && !error && <p>Loading...</p>}
+      {data && <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Projects() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/projects')
+      .then((res) => {
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Projects</h1>
+      <Link href="/"><button>Back</button></Link>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {!data && !error && <p>Loading...</p>}
+      {data && <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}

--- a/pages/reports.js
+++ b/pages/reports.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+export default function Reports() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetch('/reports')
+      .then((res) => {
+        if (!res.ok) throw new Error('Request failed');
+        return res.json();
+      })
+      .then(setData)
+      .catch((err) => setError(err.message));
+  }, []);
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Reports</h1>
+      <Link href="/"><button>Back</button></Link>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {!data && !error && <p>Loading...</p>}
+      {data && <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add React pages for Projects, Entries, Invoices and Reports
- each page fetches the corresponding Express endpoint and displays JSON

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848634837b883298db4879895bcef0c