### PR TITLE
Add additional project details

### DIFF
--- a/pages/api/projects.ts
+++ b/pages/api/projects.ts
@@ -6,7 +6,9 @@ export default async function handler(
   res: NextApiResponse
 ) {
   try {
-    const { data } = await paymo.get('/projects');
+    const { data } = await paymo.get('/projects', {
+      params: { include: 'client' },
+    });
 
     const projects = (data as any).projects || data;
 
@@ -26,12 +28,19 @@ export default async function handler(
           // Ignore errors when computing time
         }
 
+        const projectRate = p.flat_billing ? p.price : p.price_per_hour;
+        const billingType =
+          p.billing_type ?? (p.billable ? (p.flat_billing ? 'flat' : 'pph') : 'non');
+
         return {
           ...p,
+          client_name: p.client?.name ?? '',
+          project_rate: projectRate ?? null,
           time_worked: timeWorked,
           recorded_time: timeWorked,
           start_date: p.start_date ?? p.created_on,
           end_date: p.end_date ?? null,
+          billing_type: billingType,
         };
       })
     );

--- a/sections/projects.md
+++ b/sections/projects.md
@@ -45,6 +45,10 @@ Example response for listing requests:
          "budget_hours": 0.25,
          "price_per_hour": 0,
          "billable": false,
+         "start_date": "2014-10-03",
+         "end_date": null,
+         "time_worked": 0,
+         "recorded_time": 0,
          "color": "#68BE5E",
          "users": [
             23129
@@ -67,6 +71,10 @@ Example response for listing requests:
          "budget_hours": 10,
          "price_per_hour": 30,
          "billable": true,
+         "start_date": "2014-12-01",
+         "end_date": "2014-12-15",
+         "time_worked": 3600,
+         "recorded_time": 3600,
          "color": "#E93A55",
          "users": [
             23129,
@@ -108,6 +116,10 @@ Example of response:
          "budget_hours": 0.25,
          "price_per_hour": 0,
          "billable": false,
+         "start_date": "2014-10-03",
+         "end_date": null,
+         "time_worked": 0,
+         "recorded_time": 0,
          "color": "#68BE5E",
          "users": [
             23129
@@ -367,6 +379,10 @@ flat_billing | boolean | For billable projects, if `true` the project is *flat r
 price_per_hour | decimal | For time & materials projects, the project hourly rate. Note: which hourly rate (user, task, project, or company) will be used for billing is defined by the `hourly_billing_mode` field.
 price | decimal | For flat rate project, the project flat rate. See [billing](#billing).
 estimated_price | decimal | For billable projects, the estimated project price consisting of the price of all its billable tasks (including flat rate tasks).
+start_date | date | _(read-only)_ Project start date if set
+end_date | date | _(read-only)_ Project end date if set
+time_worked | integer | _(read-only)_ Total time tracked for the project in seconds
+recorded_time | integer | _(read-only)_ Same as `time_worked`
 hourly_billing_mode | text | For time & materials projects, defines the hierarchy of rates used when deciding on the hourly rate for billing the time in the project. See [billing](#billing).
 budget_hours | decimal | Project budget in hours. If not set, the project will have unlimited budget hours.
 adjustable_hours | boolean | If `true` the budget_hours will be adjusted automatically based on tasks budget hours.


### PR DESCRIPTION
## Summary
- return client info and rate when listing projects
- update docs with extra project fields and example values

## Testing
- `npx tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848a4bf3a8883298f211682554ab7ab