### PR TITLE
Add project fee and dates from entries

### DIFF
--- a/pages/api/projects.ts
+++ b/pages/api/projects.ts
@@ -15,31 +15,54 @@ export default async function handler(
     const detailed = await Promise.all(
       (projects as any[]).map(async (p) => {
         let timeWorked = 0;
+        let startDate: string | null = null;
+        let endDate: string | null = null;
+
         try {
-          const { data: entryData } = await paymo.get('/entries', {
-            params: { where: `project_id=${p.id}` },
+          const { data: projData } = await paymo.get(`/projects/${p.id}`, {
+            params: { include: 'tasks.entries' },
           });
-          const entries = (entryData as any).entries || [];
-          timeWorked = entries.reduce(
-            (total: number, e: any) => total + (e.duration || 0),
-            0
-          );
+
+          const detailedProject =
+            (projData as any).projects?.[0] ?? (projData as any);
+          const tasks = detailedProject.tasks || [];
+          const entries = tasks.flatMap((t: any) => t.entries || []);
+
+          if (entries.length) {
+            const startTimes = entries.map((e: any) =>
+              new Date(e.start_time ?? e.date).getTime()
+            );
+            const endTimes = entries.map((e: any) =>
+              new Date(e.end_time ?? e.start_time ?? e.date).getTime()
+            );
+            startDate = new Date(Math.min(...startTimes)).toISOString();
+            endDate = new Date(Math.max(...endTimes)).toISOString();
+
+            timeWorked = entries.reduce(
+              (total: number, e: any) => total + (e.duration || 0),
+              0
+            );
+          }
         } catch {
-          // Ignore errors when computing time
+          // Ignore errors when computing details
         }
 
         const projectRate = p.flat_billing ? p.price : p.price_per_hour;
         const billingType =
           p.billing_type ?? (p.billable ? (p.flat_billing ? 'flat' : 'pph') : 'non');
+        const projectFee = p.flat_billing
+          ? p.price ?? p.estimated_price ?? null
+          : ((p.price_per_hour ?? 0) * (timeWorked / 3600));
 
         return {
           ...p,
           client_name: p.client?.name ?? '',
           project_rate: projectRate ?? null,
+          project_fee: projectFee,
           time_worked: timeWorked,
           recorded_time: timeWorked,
-          start_date: p.start_date ?? p.created_on,
-          end_date: p.end_date ?? null,
+          start_date: startDate ?? p.start_date ?? p.created_on,
+          end_date: endDate ?? p.end_date ?? null,
           billing_type: billingType,
         };
       })

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -10,6 +10,7 @@ type Project = {
   active: boolean
   budget_hours: number | null
   price_per_hour: number | null
+  project_fee: number | null
   time_worked: number
   recorded_time: number
   start_date: string | null
@@ -54,6 +55,7 @@ export default function Projects() {
               <th style={thStyle}>Start</th>
               <th style={thStyle}>End</th>
               <th style={thStyle}>Rate</th>
+              <th style={thStyle}>Fee</th>
               <th style={thStyle}>Time Worked</th>
               <th style={thStyle}>Budget Hours</th>
               <th style={thStyle}>Recorded Time</th>
@@ -80,6 +82,7 @@ export default function Projects() {
                 <td style={tdStyle}>{project.start_date ? new Date(project.start_date).toLocaleDateString() : '—'}</td>
                 <td style={tdStyle}>{project.end_date ? new Date(project.end_date).toLocaleDateString() : '—'}</td>
                 <td style={tdStyle}>{project.price_per_hour ?? '—'}</td>
+                <td style={tdStyle}>{project.project_fee?.toFixed(2) ?? '—'}</td>
                 <td style={tdStyle}>{(project.time_worked / 3600).toFixed(2)}</td>
                 <td style={tdStyle}>{project.budget_hours ?? '—'}</td>
                 <td style={tdStyle}>{(project.recorded_time / 3600).toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- compute each project's start and end dates from task entries
- calculate project fee depending on billing mode
- show project fee on projects page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848a905f92c83298c72a9e1ae0168dc