### PR TITLE
Add global password protection

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname.startsWith('/api/login') ||
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon.ico')
+  ) {
+    return NextResponse.next();
+  }
+
+  if (pathname === '/login') {
+    return NextResponse.next();
+  }
+
+  const auth = request.cookies.get('auth');
+  if (auth?.value === 'true') {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = '/login';
+  url.searchParams.set('from', pathname);
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: '/:path*',
+};

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const PASSWORD = 'P1i5p9;_';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { password } = req.body;
+    if (password === PASSWORD) {
+      res.setHeader('Set-Cookie', 'auth=true; Path=/; HttpOnly; SameSite=Lax');
+      res.status(200).json({ ok: true });
+    } else {
+      res.status(401).json({ ok: false });
+    }
+  } else if (req.method === 'DELETE') {
+    res.setHeader('Set-Cookie', 'auth=; Path=/; Max-Age=0');
+    res.status(200).json({ ok: true });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+    if (res.ok) {
+      const from = (router.query.from as string) || '/';
+      router.push(from);
+    } else {
+      setError('Contrase\u00f1a incorrecta');
+    }
+  };
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Autenticaci\u00f3n requerida</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', gap: '10px' }}>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Contrase\u00f1a"
+        />
+        <button type="submit">Entrar</button>
+      </form>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add login API route and Login page
- enforce cookie authentication with middleware

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848ec297d4c832995dbe29df085e2e9