### PR TITLE
Add project budget performance utilities

### DIFF
--- a/lib/performance.ts
+++ b/lib/performance.ts
@@ -1,0 +1,87 @@
+import paymo from './paymo';
+
+export interface ProjectPerformance {
+  project_id: number;
+  name: string;
+  total_logged_hours: number;
+  budgeted_hours: number | null;
+  budgeted_cost: number;
+  actual_cost: number;
+  cost_variance: number;
+  status: string;
+}
+
+/**
+ * Fetches performance metrics for all projects in the account.
+ *
+ * @param from Optional start date (YYYY-MM-DD) to filter time entries
+ * @param to Optional end date (YYYY-MM-DD) to filter time entries
+ * @returns Array of ProjectPerformance objects
+ */
+export async function getProjectPerformance(
+  from?: string,
+  to?: string
+): Promise<ProjectPerformance[]> {
+  const { data } = await paymo.get('/projects', { params: { include: 'tasks' } });
+  const projects = (data as any).projects ?? data;
+
+  const summaries: ProjectPerformance[] = await Promise.all(
+    (projects as any[]).map(async (project) => {
+      const whereClauses = [`project_id=${project.id}`];
+      if (from) whereClauses.push(`date>="${from}"`);
+      if (to) whereClauses.push(`date<="${to}"`);
+      const where = whereClauses.join(' and ');
+
+      let totalSeconds = 0;
+      try {
+        const { data: entriesData } = await paymo.get('/entries', {
+          params: { where, include: 'task' },
+        });
+        const entries = (entriesData as any).entries ?? entriesData ?? [];
+        totalSeconds = (entries as any[]).reduce(
+          (sum, e) => sum + (e.duration ?? 0),
+          0
+        );
+      } catch {
+        // ignore errors fetching entries for a project
+      }
+
+      const loggedHours = totalSeconds / 3600;
+
+      // compute budget hours
+      let budgetHours = project.budget_hours ?? 0;
+      const tasks = project.tasks ?? [];
+      const taskBudgets = tasks.reduce(
+        (sum: number, t: any) => sum + (t.budget_hours ?? 0),
+        0
+      );
+      if (!budgetHours && taskBudgets) {
+        budgetHours = taskBudgets;
+      }
+
+      const rate = project.flat_billing
+        ? 0
+        : project.price_per_hour ?? 0;
+      const budgetedCost = project.flat_billing
+        ? project.price ?? project.estimated_price ?? 0
+        : budgetHours * rate;
+      const actualCost = loggedHours * rate;
+
+      const summary: ProjectPerformance = {
+        project_id: project.id,
+        name: project.name,
+        total_logged_hours: loggedHours,
+        budgeted_hours: budgetHours || null,
+        budgeted_cost: budgetedCost,
+        actual_cost: actualCost,
+        cost_variance: budgetedCost - actualCost,
+        status: actualCost <= budgetedCost
+          ? 'Dentro del presupuesto'
+          : 'Sobre el presupuesto',
+      };
+      return summary;
+    })
+  );
+
+  return summaries;
+}

--- a/pages/api/performance.ts
+++ b/pages/api/performance.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getProjectPerformance } from '../../lib/performance';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { from, to } = req.query;
+  try {
+    const data = await getProjectPerformance(
+      typeof from === 'string' ? from : undefined,
+      typeof to === 'string' ? to : undefined
+    );
+    res.status(200).json(data);
+  } catch (err) {
+    console.error((err as Error).message);
+    res.status(500).json({ error: 'Failed to compute performance' });
+  }
+}


### PR DESCRIPTION
## Summary
- implement helper `getProjectPerformance` for computing budget variance per project
- expose new API route `/api/performance`

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848ef85faec8329be591573d89ce2ab