### PR TITLE
Add project performance metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This repository now uses the built-in API routes from Next.js. The following end
 * `/api/entries` – Get time entries
 * `/api/invoices` – Retrieve invoices
 * `/api/reports` – Generate reports
+* `/api/performance` – Project performance metrics
 
 ### Usage
 

--- a/lib/performance.ts
+++ b/lib/performance.ts
@@ -8,6 +8,7 @@ export interface ProjectPerformance {
   budgeted_cost: number;
   actual_cost: number;
   cost_variance: number;
+  cost_performance_index: number | null;
   status: string;
 }
 
@@ -67,6 +68,8 @@ export async function getProjectPerformance(
         : budgetHours * rate;
       const actualCost = loggedHours * rate;
 
+      const costPerformanceIndex = actualCost > 0 ? budgetedCost / actualCost : null;
+
       const summary: ProjectPerformance = {
         project_id: project.id,
         name: project.name,
@@ -75,6 +78,7 @@ export async function getProjectPerformance(
         budgeted_cost: budgetedCost,
         actual_cost: actualCost,
         cost_variance: budgetedCost - actualCost,
+        cost_performance_index: costPerformanceIndex,
         status: actualCost <= budgetedCost
           ? 'Dentro del presupuesto'
           : 'Sobre el presupuesto',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,8 +12,9 @@ export default function Home() {
         <Link href="/entries"><button>Entries</button></Link>
         <Link href="/invoices"><button>Invoices</button></Link>
         <Link href="/reports"><button>Reports</button></Link>
+        <Link href="/performance"><button>Performance</button></Link>
       </div>
-       <Loader /> 
+       <Loader />
     </div>
   );
 }

--- a/pages/performance.tsx
+++ b/pages/performance.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import Loader from './components/loader'
+
+interface Perf {
+  project_id: number
+  name: string
+  total_logged_hours: number
+  budgeted_hours: number | null
+  budgeted_cost: number
+  actual_cost: number
+  cost_variance: number
+  cost_performance_index: number | null
+  status: string
+}
+
+export default function Performance() {
+  const [data, setData] = useState<Perf[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch('/api/performance')
+      .then((res) => {
+        if (!res.ok) throw new Error('Request failed')
+        return res.json()
+      })
+      .then(setData)
+      .catch((err) => setError(err.message))
+  }, [])
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
+      <h1>Performance</h1>
+      <Link href="/"><button>Back</button></Link>
+      {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+      {!data && !error && <Loader />}
+      {data && (
+        <table style={{
+          width: '100%',
+          borderCollapse: 'collapse',
+          marginTop: '20px',
+          fontSize: '14px'
+        }}>
+          <thead>
+            <tr style={{ backgroundColor: '#f0f0f0' }}>
+              <th style={thStyle}>Project</th>
+              <th style={thStyle}>Logged Hours</th>
+              <th style={thStyle}>Budgeted Hours</th>
+              <th style={thStyle}>Budgeted Cost</th>
+              <th style={thStyle}>Actual Cost</th>
+              <th style={thStyle}>Cost Variance</th>
+              <th style={thStyle}>CPI</th>
+              <th style={thStyle}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((p) => (
+              <tr key={p.project_id}>
+                <td style={tdStyle}>{p.name}</td>
+                <td style={tdStyle}>{p.total_logged_hours.toFixed(2)}</td>
+                <td style={tdStyle}>{p.budgeted_hours ?? '—'}</td>
+                <td style={tdStyle}>${p.budgeted_cost.toFixed(2)}</td>
+                <td style={tdStyle}>${p.actual_cost.toFixed(2)}</td>
+                <td style={tdStyle}>${p.cost_variance.toFixed(2)}</td>
+                <td style={tdStyle}>{p.cost_performance_index?.toFixed(2) ?? '—'}</td>
+                <td style={tdStyle}>{p.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  )
+}
+
+const thStyle = {
+  border: '1px solid #ccc',
+  padding: '8px',
+  textAlign: 'left' as const,
+}
+
+const tdStyle = {
+  border: '1px solid #ccc',
+  padding: '8px',
+}


### PR DESCRIPTION
## Summary
- add new page for project performance reports
- expose `/api/performance` endpoint in README
- compute CPI metric in `lib/performance.ts`
- link to performance page from the homepage

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848f4d7cd788329b91c913c201a4597