### PR TITLE
User key input

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ This repository now uses the built-in API routes from Next.js. The following end
 
 ### Usage
 
-1. Copy `.env.example` to `.env` and add your Paymo API key.
+1. Copy `.env.example` to `.env` and add your Paymo API key, or simply provide
+   the key on the login page when starting the interface.
 2. Install dependencies:
 
 ```bash
@@ -181,5 +182,7 @@ The server listens on port `3000` by default. Visit `http://localhost:3000/` for
 
 ### Troubleshooting
 
-If any request responds with `401 Unauthorized`, verify that the `PAYMO_API_KEY` in your `.env` file is correct. The API routes rely on this key to authenticate with Paymo.
+If any request responds with `401 Unauthorized`, ensure the API key you entered
+on login (or in your `.env` file) is correct. The API routes rely on this key to
+authenticate with Paymo.
 

--- a/lib/paymo.ts
+++ b/lib/paymo.ts
@@ -1,20 +1,22 @@
-import axios from 'axios';
+import axios, { AxiosInstance } from 'axios';
 
-const PAYMO_API_KEY = process.env.PAYMO_API_KEY;
-
-if (!PAYMO_API_KEY) {
-  throw new Error('PAYMO_API_KEY not defined in environment');
+export function createPaymoClient(apiKey: string): AxiosInstance {
+  return axios.create({
+    baseURL: 'https://app.paymoapp.com/api',
+    headers: {
+      Accept: 'application/json',
+    },
+    auth: {
+      username: apiKey,
+      password: 'X',
+    },
+  });
 }
 
-const paymo = axios.create({
-  baseURL: 'https://app.paymoapp.com/api',
-  headers: {
-    Accept: 'application/json',
-  },
-  auth: {
-    username: PAYMO_API_KEY,
-    password: 'X',
-  },
-});
-
-export default paymo;
+export function getEnvPaymoClient(): AxiosInstance {
+  const key = process.env.PAYMO_API_KEY;
+  if (!key) {
+    throw new Error('PAYMO_API_KEY not defined in environment');
+  }
+  return createPaymoClient(key);
+}

--- a/lib/performance.ts
+++ b/lib/performance.ts
@@ -1,4 +1,4 @@
-import paymo from './paymo';
+import type { AxiosInstance } from 'axios';
 
 export interface ProjectPerformance {
   project_id: number;
@@ -20,6 +20,7 @@ export interface ProjectPerformance {
  * @returns Array of ProjectPerformance objects
  */
 export async function getProjectPerformance(
+  paymo: AxiosInstance,
   from?: string,
   to?: string
 ): Promise<ProjectPerformance[]> {

--- a/pages/api/entries.ts
+++ b/pages/api/entries.ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import paymo from '../../lib/paymo';
+import { createPaymoClient } from '../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
+
   try {
     const { data } = await paymo.get('/entries');
     res.status(200).json((data as any).entries || data);

--- a/pages/api/invoices.ts
+++ b/pages/api/invoices.ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import paymo from '../../lib/paymo';
+import { createPaymoClient } from '../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
+
   try {
     const { data } = await paymo.get('/invoices');
     res.status(200).json((data as any).invoices || data);

--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -4,15 +4,22 @@ const PASSWORD = 'P1i5p9;_';
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
-    const { password } = req.body;
+    const { password, apiKey } = req.body;
     if (password === PASSWORD) {
-      res.setHeader('Set-Cookie', 'auth=true; Path=/; HttpOnly; SameSite=Lax');
+      const cookies = ['auth=true; Path=/; HttpOnly; SameSite=Lax'];
+      if (apiKey) {
+        cookies.push(`paymo_api_key=${apiKey}; Path=/; HttpOnly; SameSite=Lax`);
+      }
+      res.setHeader('Set-Cookie', cookies);
       res.status(200).json({ ok: true });
     } else {
       res.status(401).json({ ok: false });
     }
   } else if (req.method === 'DELETE') {
-    res.setHeader('Set-Cookie', 'auth=; Path=/; Max-Age=0');
+    res.setHeader('Set-Cookie', [
+      'auth=; Path=/; Max-Age=0',
+      'paymo_api_key=; Path=/; Max-Age=0',
+    ]);
     res.status(200).json({ ok: true });
   } else {
     res.status(405).end();

--- a/pages/api/performance.ts
+++ b/pages/api/performance.ts
@@ -1,13 +1,23 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { getProjectPerformance } from '../../lib/performance';
+import { createPaymoClient } from '../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
   const { from, to } = req.query;
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
+
   try {
     const data = await getProjectPerformance(
+      paymo,
       typeof from === 'string' ? from : undefined,
       typeof to === 'string' ? to : undefined
     );

--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import paymo from '../../../lib/paymo';
+import { createPaymoClient } from '../../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
@@ -10,6 +10,14 @@ export default async function handler(
     res.status(400).json({ error: 'Invalid project id' });
     return;
   }
+
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
 
   try {
     const { data } = await paymo.get(`/projects/${id}`, {

--- a/pages/api/projects/index.ts
+++ b/pages/api/projects/index.ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import paymo from '../../../lib/paymo';
+import { createPaymoClient } from '../../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
+
   try {
     const { data } = await paymo.get('/projects', {
       params: { include: 'client', where: 'active=true' },

--- a/pages/api/reports.ts
+++ b/pages/api/reports.ts
@@ -1,10 +1,18 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import paymo from '../../lib/paymo';
+import { createPaymoClient } from '../../lib/paymo';
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
+  const apiKey = req.cookies.paymo_api_key || process.env.PAYMO_API_KEY;
+  if (!apiKey) {
+    res.status(401).json({ error: 'API key not provided' });
+    return;
+  }
+
+  const paymo = createPaymoClient(apiKey);
+
   try {
     const { data } = await paymo.get('/reports');
     res.status(200).json((data as any).reports || data);

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 
 export default function Login() {
   const [password, setPassword] = useState('');
+  const [apiKey, setApiKey] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
 
@@ -11,7 +12,7 @@ export default function Login() {
     const res = await fetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password }),
+      body: JSON.stringify({ password, apiKey }),
     });
     if (res.ok) {
       const from = (router.query.from as string) || '/';
@@ -23,13 +24,20 @@ export default function Login() {
 
   return (
     <div className="p-5 font-sans">
-      <h1 className="text-xl font-bold mb-2">Enter a password</h1>
-      <form onSubmit={handleSubmit} className="flex gap-2">
+      <h1 className="text-xl font-bold mb-2">Enter your credentials</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2 max-w-sm">
         <input
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder="Password"
+          className="border px-2 py-1"
+        />
+        <input
+          type="text"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="Paymo API key"
           className="border px-2 py-1"
         />
         <button type="submit" className="px-4 py-1 bg-blue-500 text-white rounded">Enter</button>


### PR DESCRIPTION
## Summary
- support providing Paymo API key at login
- create Paymo clients on demand
- fetch API key from cookie in all API routes
- adjust login page and docs

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b4446e02083299e65f1c1da9b69da