### PR TITLE
Add logout button

### DIFF
--- a/pages/components/logoutButton.tsx
+++ b/pages/components/logoutButton.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router'
+
+export default function LogoutButton() {
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    try {
+      await fetch('/api/login', { method: 'DELETE' })
+    } catch {
+      // ignore network errors
+    }
+
+    if (typeof window !== 'undefined') {
+      try { localStorage.clear() } catch {}
+      try { sessionStorage.clear() } catch {}
+    }
+
+    router.push('/login')
+  }
+
+  return (
+    <button onClick={handleLogout} className="px-4 py-2 border rounded bg-red-500 text-white">
+      Logout
+    </button>
+  )
+}

--- a/pages/entries.tsx
+++ b/pages/entries.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Loader from './components/loader'
+import LogoutButton from './components/logoutButton'
 
 type Entry = {
   id: number
@@ -31,6 +32,7 @@ export default function Entries() {
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Entries</h1>
       <Link href="/"><button>Back</button></Link>
+      <LogoutButton />
       {error && <p style={{ color: 'red' }}>Error: {error}</p>}
       {!data && !error && <Loader />}
       {data && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Loader from '../pages/components/loader';
+import LogoutButton from '../pages/components/logoutButton';
 
 
 export default function Home() {
@@ -13,6 +14,7 @@ export default function Home() {
         <Link href="/invoices"><button className="px-4 py-2 border rounded">Invoices</button></Link>
         <Link href="/reports"><button className="px-4 py-2 border rounded">Reports</button></Link>
         <Link href="/performance"><button className="px-4 py-2 border rounded">Performance</button></Link>
+        <LogoutButton />
       </div>
        <Loader />
     </div>

--- a/pages/invoices.tsx
+++ b/pages/invoices.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
+import LogoutButton from './components/logoutButton'
 
 type Invoice = {
   id: number
@@ -33,6 +34,7 @@ export default function Invoices() {
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Invoices</h1>
       <Link href="/"><button>Back</button></Link>
+      <LogoutButton />
       {error && <p style={{ color: 'red' }}>Error: {error}</p>}
       {!data && !error && <p>Loading...</p>}
       {data && (

--- a/pages/performance.tsx
+++ b/pages/performance.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import Loader from "./components/loader";
+import LogoutButton from "./components/logoutButton";
 
 interface Perf {
   project_id: number;
@@ -43,6 +44,7 @@ export default function Performance() {
       <Link href="/">
         <button>Back</button>
       </Link>
+      <LogoutButton />
 
       <div style={{ marginTop: "20px", marginBottom: "10px", display: "flex" }}>
         <input

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Loader from './components/loader'
+import LogoutButton from './components/logoutButton'
 
 type ProjectSummary = {
   id: number
@@ -63,6 +64,7 @@ export default function Projects() {
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Projects</h1>
       <Link href="/"><button>Back</button></Link>
+      <LogoutButton />
       {error && <p style={{ color: 'red' }}>Error: {error}</p>}
       {!data && !error && <Loader/>}
       {data && (

--- a/pages/reports.tsx
+++ b/pages/reports.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Loader from './components/loader'
+import LogoutButton from './components/logoutButton'
 
 type Report = {
   id: number
@@ -36,6 +37,7 @@ export default function Reports() {
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
       <h1>Reports</h1>
       <Link href="/"><button>Back</button></Link>
+      <LogoutButton />
       {error && <p style={{ color: 'red' }}>Error: {error}</p>}
       {!data && !error && <Loader />}
       {data && (


### PR DESCRIPTION
## Summary
- add reusable `LogoutButton` component
- display logout control on all user-facing pages

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: no test specified)*
- `npx tsc --noEmit` *(fails: packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b48c2605883298811544250f844f6