### PR TITLE
Fix inaccurate time worked in project details

### DIFF
--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -30,7 +30,7 @@ export default async function handler(
       return;
     }
 
-    let timeWorked = 0;
+    let timeWorked = typeof p.time_worked === 'number' ? p.time_worked : 0;
     let startDate: string | null = null;
     let endDate: string | null = null;
 
@@ -47,10 +47,12 @@ export default async function handler(
       startDate = new Date(Math.min(...startTimes)).toISOString();
       endDate = new Date(Math.max(...endTimes)).toISOString();
 
-      timeWorked = entries.reduce(
-        (total: number, e: any) => total + (e.duration || 0),
-        0
-      );
+      if (!p.time_worked) {
+        timeWorked = entries.reduce(
+          (total: number, e: any) => total + (e.duration || 0),
+          0
+        );
+      }
     }
 
     const projectRate = p.flat_billing ? p.price : p.price_per_hour;
@@ -70,7 +72,7 @@ export default async function handler(
       price_per_hour: p.price_per_hour ?? null,
       project_fee: projectFee,
       time_worked: timeWorked,
-      recorded_time: timeWorked,
+      recorded_time: typeof p.recorded_time === 'number' ? p.recorded_time : timeWorked,
       start_date: startDate ?? p.start_date ?? p.created_on,
       end_date: endDate ?? p.end_date ?? null,
       billing_type: billingType,


### PR DESCRIPTION
## Summary
- get project `time_worked` value directly from the Paymo API
- only fall back to summing entry durations when the API doesn't return it
- send the `recorded_time` provided by Paymo if available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dcc980c8329987d1aba478f5c51