### PR TITLE
Fix inaccurate time worked in project details

### DIFF
--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -21,7 +21,7 @@ export default async function handler(
 
   try {
     const { data } = await paymo.get(`/projects/${id}`, {
-      params: { include: 'client,tasks.entries' },
+      params: { include: 'client' },
     });
     const p = (data as any).projects?.[0] ?? (data as any);
 
@@ -30,12 +30,14 @@ export default async function handler(
       return;
     }
 
-    let timeWorked = 0;
+    let timeWorked = typeof p.time_worked === 'number' ? p.time_worked : 0;
     let startDate: string | null = null;
     let endDate: string | null = null;
 
-    const tasks = p.tasks || [];
-    const entries = tasks.flatMap((t: any) => t.entries || []);
+    const { data: entriesData } = await paymo.get('/entries', {
+      params: { where: `project_id=${id}` },
+    });
+    const entries = (entriesData as any).entries ?? entriesData ?? [];
 
     if (entries.length) {
       const startTimes = entries.map((e: any) =>
@@ -47,10 +49,12 @@ export default async function handler(
       startDate = new Date(Math.min(...startTimes)).toISOString();
       endDate = new Date(Math.max(...endTimes)).toISOString();
 
-      timeWorked = entries.reduce(
-        (total: number, e: any) => total + (e.duration || 0),
-        0
-      );
+      if (!p.time_worked) {
+        timeWorked = entries.reduce(
+          (total: number, e: any) => total + (e.duration || 0),
+          0
+        );
+      }
     }
 
     const projectRate = p.flat_billing ? p.price : p.price_per_hour;
@@ -70,7 +74,7 @@ export default async function handler(
       price_per_hour: p.price_per_hour ?? null,
       project_fee: projectFee,
       time_worked: timeWorked,
-      recorded_time: timeWorked,
+      recorded_time: typeof p.recorded_time === 'number' ? p.recorded_time : timeWorked,
       start_date: startDate ?? p.start_date ?? p.created_on,
       end_date: endDate ?? p.end_date ?? null,
       billing_type: billingType,


### PR DESCRIPTION
## Summary
- request project details with `include=client`
- fetch all time entries for the project separately
- derive start/end dates and total hours from those entries when needed

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dcc980c8329987d1aba478f5c51