### PR TITLE
Fix time worked and display hours/minutes

### DIFF
--- a/lib/performance.ts
+++ b/lib/performance.ts
@@ -36,10 +36,10 @@ export async function getProjectPerformance(
 
       let totalSeconds = 0;
       try {
-        const { data: entriesData } = await paymo.get('/entries', {
+        const { data: entriesData } = await paymo.get('/time_entries', {
           params: { where, include: 'task' },
         });
-        const entries = (entriesData as any).entries ?? entriesData ?? [];
+        const entries = (entriesData as any).time_entries ?? entriesData?.entries ?? entriesData ?? [];
         totalSeconds = (entries as any[]).reduce(
           (sum, e) => sum + (e.duration ?? 0),
           0

--- a/lib/time.ts
+++ b/lib/time.ts
@@ -1,0 +1,5 @@
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  return `${h}h ${m}m`;
+}

--- a/pages/api/entries.ts
+++ b/pages/api/entries.ts
@@ -14,8 +14,8 @@ export default async function handler(
   const paymo = createPaymoClient(apiKey);
 
   try {
-    const { data } = await paymo.get('/entries');
-    res.status(200).json((data as any).entries || data);
+    const { data } = await paymo.get('/time_entries');
+    res.status(200).json((data as any).time_entries || (data as any).entries || data);
   } catch (err) {
     console.error((err as Error).message);
     res.status(500).json({ error: 'Failed to fetch entries' });

--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -21,7 +21,7 @@ export default async function handler(
 
   try {
     const { data } = await paymo.get(`/projects/${id}`, {
-      params: { include: 'client,tasks.entries' },
+      params: { include: 'client' },
     });
     const p = (data as any).projects?.[0] ?? (data as any);
 
@@ -30,12 +30,14 @@ export default async function handler(
       return;
     }
 
-    let timeWorked = 0;
+    let timeWorked = typeof p.time_worked === 'number' ? p.time_worked : 0;
     let startDate: string | null = null;
     let endDate: string | null = null;
 
-    const tasks = p.tasks || [];
-    const entries = tasks.flatMap((t: any) => t.entries || []);
+    const { data: entriesData } = await paymo.get('/time_entries', {
+      params: { where: `project_id=${id}` },
+    });
+    const entries = (entriesData as any).time_entries ?? entriesData?.entries ?? entriesData ?? [];
 
     if (entries.length) {
       const startTimes = entries.map((e: any) =>
@@ -47,10 +49,12 @@ export default async function handler(
       startDate = new Date(Math.min(...startTimes)).toISOString();
       endDate = new Date(Math.max(...endTimes)).toISOString();
 
-      timeWorked = entries.reduce(
-        (total: number, e: any) => total + (e.duration || 0),
-        0
-      );
+      if (!p.time_worked) {
+        timeWorked = entries.reduce(
+          (total: number, e: any) => total + (e.duration || 0),
+          0
+        );
+      }
     }
 
     const projectRate = p.flat_billing ? p.price : p.price_per_hour;
@@ -70,7 +74,7 @@ export default async function handler(
       price_per_hour: p.price_per_hour ?? null,
       project_fee: projectFee,
       time_worked: timeWorked,
-      recorded_time: timeWorked,
+      recorded_time: typeof p.recorded_time === 'number' ? p.recorded_time : timeWorked,
       start_date: startDate ?? p.start_date ?? p.created_on,
       end_date: endDate ?? p.end_date ?? null,
       billing_type: billingType,

--- a/pages/entries.tsx
+++ b/pages/entries.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Loader from './components/loader'
 import LogoutButton from './components/logoutButton'
+import { formatDuration } from '../lib/time'
 
 type Entry = {
   id: number
@@ -57,7 +58,7 @@ export default function Entries() {
               <tr key={entry.id}>
                 <td style={tdStyle}>{entry.date}</td>
                 <td style={tdStyle}>{entry.task_id}</td>
-                <td style={tdStyle}>{(entry.duration / 3600).toFixed(2)}</td>
+                <td style={tdStyle}>{formatDuration(entry.duration)}</td>
                 <td style={tdStyle}>${entry.cost}</td>
                 <td style={tdStyle}>${entry.price}</td>
                 <td style={{ ...tdStyle, textTransform: 'capitalize' }}>{entry.status}</td>

--- a/pages/performance.tsx
+++ b/pages/performance.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import Loader from "./components/loader";
 import LogoutButton from "./components/logoutButton";
+import { formatDuration } from "../lib/time";
 
 interface Perf {
   project_id: number;
@@ -168,11 +169,11 @@ export default function Performance() {
                 </td>
                 <td style={tdStyle}>{p.status}</td>
                 <td style={tdStyle}>{p.budgeted_hours ?? "—"}</td>
-                <td style={tdStyle}>{p.total_logged_hours.toFixed(2)}</td>
+                <td style={tdStyle}>{formatDuration(p.total_logged_hours * 3600)}</td>
                 <td style={tdStyle}>
                   {p.budgeted_hours === null
                     ? "—"
-                    : (p.budgeted_hours - p.total_logged_hours).toFixed(2)}
+                    : formatDuration((p.budgeted_hours - p.total_logged_hours) * 3600)}
                 </td>
                 <td style={tdStyle}>${p.budgeted_cost.toFixed(2)}</td>
                 <td style={tdStyle}>${p.actual_cost.toFixed(2)}</td>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import Loader from './components/loader'
 import LogoutButton from './components/logoutButton'
+import { formatDuration } from '../lib/time'
 
 type ProjectSummary = {
   id: number
@@ -140,7 +141,7 @@ export default function Projects() {
               </tr>
               <tr>
                 <td style={tdStyle}>Time Worked</td>
-                <td style={tdStyle}>{(selected.time_worked / 3600).toFixed(2)}</td>
+                <td style={tdStyle}>{formatDuration(selected.time_worked)}</td>
               </tr>
               <tr>
                 <td style={tdStyle}>Budget Hours</td>
@@ -148,7 +149,7 @@ export default function Projects() {
               </tr>
               <tr>
                 <td style={tdStyle}>Recorded Time</td>
-                <td style={tdStyle}>{(selected.recorded_time / 3600).toFixed(2)}</td>
+                <td style={tdStyle}>{formatDuration(selected.recorded_time)}</td>
               </tr>
               <tr>
                 <td style={tdStyle}>Billing</td>


### PR DESCRIPTION
## Summary
- fetch project hours from `/time_entries`
- adjust entries API and performance helper to use the same endpoint
- show durations as `Hh Mm` via new `formatDuration` util

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c2dcc980c8329987d1aba478f5c51