### PR TITLE
Improve Time Worked documentation

### DIFF
--- a/sections/time_worked.md
+++ b/sections/time_worked.md
@@ -35,6 +35,23 @@ Envía un objeto JSON similar al siguiente. Reemplaza `3323471` con el ID de tu 
 
 La respuesta contendrá un arreglo `reports`. Accede a `reports[0].content.items` y busca el objeto cuyo `type` sea `"total"`. El campo `time` de ese objeto representa los segundos trabajados en total para el proyecto.
 
+Un fragmento de la respuesta luce así:
+
+```json
+{
+  "reports": [
+    {
+      "content": {
+        "items": [
+          { "type": "project", "time": 2681075, "title": "Mi Proyecto" },
+          { "type": "total", "time": 2681075, "pct": 100 }
+        ]
+      }
+    }
+  ]
+}
+```
+
 Puedes convertir ese valor a horas y minutos con el siguiente código de ejemplo:
 
 ```javascript


### PR DESCRIPTION
## Summary
- elaborate docs for retrieving Time Worked via the Paymo API

## Testing
- `npm test` *(fails: no test specified)*
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f675be3f883298d6757fc8450cc7f