### PR TITLE
Improve Time Worked calculation

### DIFF
--- a/lib/performance.ts
+++ b/lib/performance.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance } from 'axios';
-import { fetchAllTimeEntries } from './time';
+import { fetchProjectWorkedSeconds } from './time';
 
 export interface ProjectPerformance {
   project_id: number;
@@ -30,38 +30,11 @@ export async function getProjectPerformance(
 
   const summaries: ProjectPerformance[] = await Promise.all(
     (projects as any[]).map(async (project) => {
-      const whereClauses = [`project_id=${project.id}`];
-      if (from) whereClauses.push(`date>="${from}"`);
-      if (to) whereClauses.push(`date<="${to}"`);
-      const where = whereClauses.join(' and ');
-
-      let totalSeconds = 0;
-      let entries: any[] = [];
-      try {
-        entries = await fetchAllTimeEntries(paymo, {
-          where,
-          include: 'task',
-        });
-      } catch {
-        entries = [];
-      }
-
-      if (!entries.length) {
-        try {
-          const { data: pData } = await paymo.get(`/projects/${project.id}`, {
-            params: { include: 'tasks.entries' },
-          });
-          const proj = (pData as any).projects?.[0] ?? pData;
-          entries = (proj.tasks || []).flatMap((t: any) => t.entries || []);
-        } catch {
-          entries = [];
-        }
-      }
-
-
-      totalSeconds = (entries as any[]).reduce(
-        (sum, e) => sum + (e.duration ?? 0),
-        0
+      const totalSeconds = await fetchProjectWorkedSeconds(
+        paymo,
+        project.id,
+        from,
+        to
       );
 
       const loggedHours = totalSeconds / 3600;

--- a/pages/api/projects/[id].ts
+++ b/pages/api/projects/[id].ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { createPaymoClient } from '../../../lib/paymo';
-import { fetchAllTimeEntries } from '../../../lib/time';
+import { fetchProjectWorkedSeconds } from '../../../lib/time';
 
 export default async function handler(
   req: NextApiRequest,
@@ -31,50 +31,9 @@ export default async function handler(
       return;
     }
 
-    let timeWorked = typeof p.time_worked === 'number' ? p.time_worked : 0;
-    let startDate: string | null = null;
-    let endDate: string | null = null;
-
-
-    let entries: any[] = [];
-    try {
-      entries = await fetchAllTimeEntries(paymo, { where: `project_id=${id}` });
-    } catch {
-      entries = [];
-
-    }
-
-    if (!entries.length) {
-      try {
-        const { data: entData } = await paymo.get(`/projects/${id}`, {
-          params: { include: 'tasks.entries' },
-        });
-        const pEnt = (entData as any).projects?.[0] ?? entData;
-        entries = (pEnt.tasks || []).flatMap((t: any) => t.entries || []);
-      } catch {
-        entries = [];
-      }
-    }
-
-
-
-    if (entries.length) {
-      const startTimes = entries.map((e: any) =>
-        new Date(e.start_time ?? e.date).getTime()
-      );
-      const endTimes = entries.map((e: any) =>
-        new Date(e.end_time ?? e.start_time ?? e.date).getTime()
-      );
-      startDate = new Date(Math.min(...startTimes)).toISOString();
-      endDate = new Date(Math.max(...endTimes)).toISOString();
-
-      if (!p.time_worked) {
-        timeWorked = entries.reduce(
-          (total: number, e: any) => total + (e.duration || 0),
-          0
-        );
-      }
-    }
+  const timeWorked = await fetchProjectWorkedSeconds(paymo, Number(id));
+  const startDate: string | null = p.start_date ?? p.created_on;
+  const endDate: string | null = p.end_date ?? null;
 
     const projectRate = p.flat_billing ? p.price : p.price_per_hour;
     const billingType =

--- a/sections/time_worked.md
+++ b/sections/time_worked.md
@@ -35,12 +35,33 @@ Envía un objeto JSON similar al siguiente. Reemplaza `3323471` con el ID de tu 
 
 La respuesta contendrá un arreglo `reports`. Accede a `reports[0].content.items` y busca el objeto cuyo `type` sea `"total"`. El campo `time` de ese objeto representa los segundos trabajados en total para el proyecto.
 
+En el caso del proyecto con ID `3323471`, el valor recibido es `2681075` segundos, que corresponden a **744h 44m** de trabajo.
+
+Un fragmento de la respuesta luce así:
+
+```json
+{
+  "reports": [
+    {
+      "content": {
+        "items": [
+          { "type": "project", "time": 2681075, "title": "Mi Proyecto" },
+          { "type": "total", "time": 2681075, "pct": 100 }
+        ]
+      }
+    }
+  ]
+}
+```
+
 Puedes convertir ese valor a horas y minutos con el siguiente código de ejemplo:
 
 ```javascript
 const horas = Math.floor(time / 3600);
 const minutos = Math.floor((time % 3600) / 60);
-// => `${horas}h ${minutos}m`
+const resultado = `${horas}h ${minutos}m`;
+// Con el valor de ejemplo, imprime:
+// "744h 44m"
 ```
 
 Este tiempo coincide con la columna **Time Worked** que aparece en la pantalla de **Performance** de esta interfaz.


### PR DESCRIPTION
## Summary
- fetch Time Worked using the Paymo Reports endpoint
- compute performance metrics with this value
- simplify project details API

## Testing
- `npm test` *(fails: no test specified)*
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f675be3f883298d6757fc8450cc7f